### PR TITLE
fix freeze bug on pause toggle

### DIFF
--- a/Sturdy Broccoli/Assets/Scripts/PauseMenu.cs
+++ b/Sturdy Broccoli/Assets/Scripts/PauseMenu.cs
@@ -11,7 +11,16 @@ public class PauseMenu : MonoBehaviour
     public void Pause() {
         // opens the pause menu and freezes the game
         pauseMenu.SetActive(!pauseMenu.activeSelf);
-        Time.timeScale = 0f;
+        
+        // checks if game is paused and toggles freeze accordingly
+        if (pauseMenu.activeSelf)
+        {
+            Time.timeScale = 0f;
+        } 
+        else
+        {
+            Time.timeScale = 1f;
+        }
     }
 
     public void Resume() {


### PR DESCRIPTION
Here I just simply added an if-statement to check if the pause menu was toggled.
This can set the timescale of the game accordingly.

The previous issue without doing this, was that when the player unpaused with the escape key, the game was still in a frozen state, as the timescale hasn't been reset to 1f.